### PR TITLE
Update Wikidata reconciliation service URL

### DIFF
--- a/cloudapp/src/app/models/refineServices.json
+++ b/cloudapp/src/app/models/refineServices.json
@@ -13,7 +13,7 @@
   {
     "name": "Wikidata",
     "description": "",
-    "url": "https://tools.wmflabs.org/openrefine-wikidata/en/api",
+    "url": "https://wdreconcile.toolforge.org/en/api",
     "prefix": "",
     "fields": [
       { "tag": "100", "subfield": "a", "indexes": [], "subfield2": [] }


### PR DESCRIPTION
We unfortunately had to change the canonical URL of the service. This will avoid going through redirects each time.